### PR TITLE
Add-on SDK 1.0b5 での deplicate warning の修正

### DIFF
--- a/data/context_menu.js
+++ b/data/context_menu.js
@@ -1,13 +1,13 @@
-on('context', function (node) {
+self.on('context', function (node) {
     return document.getElementById('autopagerize_message_bar');
 })
-on('click', function (node, data) {
+self.on('click', function (node, data) {
     if (data == 'toggle') {
         var ev = document.createEvent('Event');
         ev.initEvent('AutoPagerizeToggleRequest', true, false)
         document.dispatchEvent(ev)
     }
     else if (data == 'config') {
-        postMessage('show_config_panel')
+        self.postMessage('show_config_panel')
     }
 })

--- a/data/extension.js
+++ b/data/extension.js
@@ -25,9 +25,9 @@ function Extension() {
         })
     }
     else if (Extension.isFirefox()) {
-        onMessage = function(res) {
+        self.on('message', function(res) {
             callback({ name: res.name, data: res.data })
-        }
+        })
     }
 }
 Extension.prototype.postMessage = function(name, data, callback) {
@@ -39,7 +39,7 @@ Extension.prototype.postMessage = function(name, data, callback) {
         this.port.postMessage({ name: name, data: data })
     }
     else if (Extension.isFirefox()) {
-        postMessage({ name: name, data: data })
+        self.postMessage({ name: name, data: data })
     }
 }
 Extension.prototype.addListener = function(name, callback) {

--- a/data/options.js
+++ b/data/options.js
@@ -5,14 +5,14 @@ form.addEventListener('submit', function(event) {
     var d = {}
     d['exclude_patterns'] = form_ep.value
     d['display_message_bar'] = !!form_dm.checked
-    postMessage({ name: 'settingsUpdate', data: d })
+    self.postMessage({ name: 'settingsUpdate', data: d })
     event.preventDefault()
 }, false)
 
 var us = document.getElementById('update_siteinfo')
 us.addEventListener('click', updateCacheInfo, false)
 
-onMessage = function(res) {
+self.on('message', function(res) {
     // console.log('options.js:onMessage', JSON.stringify(res))
     if (res.name == 'settings') {
         var settings = res.data
@@ -36,17 +36,17 @@ onMessage = function(res) {
         }
     }
     else if (res.name == 'onshow') {
-        postMessage({ name: 'settings' })
+        self.postMessage({ name: 'settings' })
         updateCacheInfoInfo()
     }
-}
+})
 
 function updateCacheInfoInfo() {
-    postMessage({ name: 'siteinfo_meta' })
+    self.postMessage({ name: 'siteinfo_meta' })
 }
 
 function updateCacheInfo() {
     us.disabled = true
     us.value = 'Updateing...'
-    postMessage({ name: 'update_siteinfo' })
+    self.postMessage({ name: 'update_siteinfo' })
 }


### PR DESCRIPTION
アドオンの AutoPagerize がメモリリークしている件ですが、原因が Add-on SDK のバグなので SDK を最新のものに変えて xpi をビルドすれば解決するのではないかと思います。
詳しくは http://xkansan.tumblr.com/post/5478570945/autopagerize-memory-leak に書いていますので、よければご覧ください。

Add-on SDK 1.0b5 で試したところ、問題なく動作したのですが duplicate warning が出ていたので一応その部分を修正しています。
