### PR TITLE
config パネルから設定を変更すると loading.html.data が使われなくなっていたのを修正

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -32,11 +32,11 @@ xhr.XMLHttpRequest.prototype.__defineGetter__(
 exports.main = function (options, callbacks) {
     if (localStorage['settings']) {
         // remove obsolete settings.
-        var mysettings = JSON.stringify(localStorage['settings'])
+        var mysettings = JSON.parse(localStorage['settings'])
         if (mysettings['loading_html'] || mysettings['error_html']) {
             delete mysettings['loading_html']
             delete mysettings['error_html']
-            localStorage['settings'] = mysettings
+            localStorage['settings'] = JSON.stringify(mysettings)
         }
     }
     else {


### PR DESCRIPTION
次ページの読み込みの際に表示される loading.html なのですが、
config パネルから設定を変更すると loading.html.data ではなく http://autopagerize.net/files/loading.html が読み込まれるようになってしまいます。

このため、一度でも config パネルから設定を変更すると、
- https のページで AutoPagerize が動作していると、「要求したページは暗号化されていますが、暗号化されていない項目を含んでいます。あなたがこのページで表示や入力する情報は第三者が簡単に傍受できます」というメッセージが表示されてしまう
- インターネットに接続していない状態でローカルサーバのコンテンツ上で AutoPagerize が動作していても loading.html が読み込まれないため表示されない

といった状態になります。

なので config パネルから設定を変更しても loading.html.data が読み込まれるようにパッチを書きました。
よければ merge お願いします。
