### PR TITLE
dealt with the Node.lookupNamespaceURI(null) bug

### DIFF
--- a/data/autopagerize.user.js
+++ b/data/autopagerize.user.js
@@ -304,7 +304,7 @@ AutoPager.prototype.addPage = function(htmlDoc, page) {
         }
     }
 
-    if (page[0] && page[0].tagName == 'TR') {
+    if (page[0] && page[0].tagName.toLowerCase() == 'tr') {
         var insertParent = this.insertPoint.parentNode
         var colNodes = getElementsByXPath('child::tr[1]/child::*[self::td or self::th]', insertParent)
 
@@ -525,7 +525,20 @@ function getXPathResult(xpath, node, resultType) {
     var doc = node.ownerDocument || node
     var resolver = doc.createNSResolver(node.documentElement || node)
     // Use |node.lookupNamespaceURI('')| for Opera 9.5
-    var defaultNS = node.lookupNamespaceURI(null)
+    // A workaround for bugs of Node.lookupNamespaceURI(null)
+    // https://bugzilla.mozilla.org/show_bug.cgi?id=693615
+    // https://bugzilla.mozilla.org/show_bug.cgi?id=694754
+    var defaultNS = null
+    try {
+        // This follows the spec: http://www.w3.org/TR/DOM-Level-3-Core/namespaces-algorithms.html#lookupNamespaceURIAlgo
+        if (node.nodeType == node.DOCUMENT_NODE) {
+            defaultNS = node.documentElement.lookupNamespaceURI(null)
+        }
+        else {
+            defaultNS = node.lookupNamespaceURI(null)
+        }
+    }
+    catch(e) {}
 
     if (defaultNS) {
         const defaultPrefix = '__default__'

--- a/lib/main.js
+++ b/lib/main.js
@@ -56,15 +56,17 @@ exports.main = function (options, callbacks) {
     pageMod.PageMod({
         include: ['http://*', 'https://*'],
         contentScriptWhen: 'ready',
-        contentScript: self.data.load('extension.js') + ';' +
-            self.data.load('autopagerize.user.js'),
+        contentScriptFile: [
+            self.data.url('extension.js'),
+            self.data.url('autopagerize.user.js')
+        ],
         onAttach: onAttach
     })
 
     contextMenu.Menu({
         label: "AutoPagerize",
         context: contextMenu.PageContext(),
-        contentScript: self.data.load('context_menu.js'),
+        contentScriptFile: self.data.url('context_menu.js'),
         items: [
             contextMenu.Item({ label: "on/off", data: "toggle" }),
             contextMenu.Item({ label: "config", data: "config" })


### PR DESCRIPTION
Node.lookupNamespaceURI(null) がエラーを出したり正しい値を返さない場合があるため、 AutoPagerize がページを継ぎ足さないケースがありました。
具体的には
- text/html のページで pageElement が tr 要素の場合 (例：http://misc-xkyrgyzstan.dotcloud.com/aptests/html/tr)
- application/xhtml+xml のページ (例：http://misc-xkyrgyzstan.dotcloud.com/aptests/xhtml/normal)

で動作していませんでした。

原因になっている Firefox のバグは
- https://bugzilla.mozilla.org/show_bug.cgi?id=693615
- https://bugzilla.mozilla.org/show_bug.cgi?id=694754

です。
少なくとも Firefox 7 では修正されないと思われるので、それまでは拡張側での対処が必要だと考えています。

動作の確認には以下の4つのページを用いました。(build with Add-on SDK 1.1)
- http://misc-xkyrgyzstan.dotcloud.com/aptests/html/normal
- http://misc-xkyrgyzstan.dotcloud.com/aptests/xhtml/normal
- http://misc-xkyrgyzstan.dotcloud.com/aptests/html/tr
- http://misc-xkyrgyzstan.dotcloud.com/aptests/xhtml/tr

その他、
- content script を contentScript オプションで読み込むとスクリプトのエラーを追いにくいので、 contentScriptFile で読み込むように
- application/xhtml+xml のページで pageElement が tr 要素の場合にページの区切りのレイアウトが乱れていたので、 text/html のページと同様になるように

それぞれ変更を加えています。
