### PR TITLE
fixed tr check

### DIFF
--- a/data/autopagerize.user.js
+++ b/data/autopagerize.user.js
@@ -304,7 +304,7 @@ AutoPager.prototype.addPage = function(htmlDoc, page) {
         }
     }
 
-    if (page[0] && page[0].tagName.toLowerCase() == 'tr') {
+    if (page[0] && page[0].nodeName.toLowerCase() == 'tr') {
         var insertParent = this.insertPoint.parentNode
         var colNodes = getElementsByXPath('child::tr[1]/child::*[self::td or self::th]', insertParent)
 


### PR DESCRIPTION
pageElement の先頭がテキストノードである場合、その tagName が undefined になるため tagName.toLowerCase() の呼び出しに失敗して AutoPagerize の動作が止まっていました。

例： http://magazine.mahjong-rule.com/colmun60.html

変更後の動作確認は Add-on SDK 1.1 と 1.2.1 を用いて、上記のページと
- http://misc-xkyrgyzstan.dotcloud.com/aptests/html/normal
- http://misc-xkyrgyzstan.dotcloud.com/aptests/xhtml/normal
- http://misc-xkyrgyzstan.dotcloud.com/aptests/html/tr
- http://misc-xkyrgyzstan.dotcloud.com/aptests/xhtml/tr

に対して行いました。

自分が先日入れた変更 (https://github.com/xKerman/autopagerize_for_firefox/commit/eef9a8df479684d6ceaec78e6d5c575267c3c927) が原因なので、お手数おかけしてしまい申し訳ありません……
