### PR TITLE
dealt with the bug 'console.log.apply is not a function'

### DIFF
--- a/data/autopagerize.user.js
+++ b/data/autopagerize.user.js
@@ -580,7 +580,19 @@ function addDefaultPrefix(xpath, prefix) {
 
 function debug() {
     if ( typeof DEBUG != 'undefined' && DEBUG ) {
-        console.log.apply(console, arguments)
+        if (typeof console.log.apply == 'function') {
+            console.log.apply(console, arguments)
+        }
+        // A workaround for the bug 'console.log.apply is not a function'
+        // https://bugzilla.mozilla.org/show_bug.cgi?id=692125
+        else {
+            var params = []
+            for (var i = 0; i < arguments.length; i++) {
+                params.push('_' + i)
+            }
+            params = params.join(',')
+            Function(params, 'console.log(' + params + ')').apply(null, arguments)
+        }
     }
 }
 


### PR DESCRIPTION
debug() 関数に用いられている console.log.apply が content script では undefined であるため( https://bugzilla.mozilla.org/show_bug.cgi?id=692125 )、 DEBUG を true にして AutoPagerize を使用している場合に 'console.log.apply is not a function' というエラーメッセージが表示されることがありました。

そこで Fucntion() を使って console.log の引数を動的に生成することで console.log.apply を使用した場合と同様の出力を得られるようにしました。
