### PR TITLE
fixed createHTMLDocumentByString() since <head> and <body> did not exist

### DIFF
--- a/data/autopagerize.user.js
+++ b/data/autopagerize.user.js
@@ -16,6 +16,8 @@
 //
 // A portion of createHTMLDocumentByString() function is:
 // Copyright (c) 2009 Hatena Co., Ltd
+// and
+// Copyright (c) 2009 os0x
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -782,6 +784,7 @@ function createHTMLDocumentByString(str) {
         fragment = htmlDoc.importNode(fragment, true)
     }
     // via https://github.com/hatena/hatena-bookmark-xul/blob/master/chrome/content/common/05-HTMLDocumentCreator.js
+    //     https://code.google.com/p/autopatchwork/source/browse/AutoPatchWork/includes/AutoPatchWork.js
     var head = htmlDoc.createElement('head')
     var headChildNames = {
         title: true,
@@ -789,9 +792,7 @@ function createHTMLDocumentByString(str) {
         link: true,
         script: true,
         style: true,
-        object: true,
-        base: true,
-        isindex: true
+        base: true
     }
     var child
     while ((child = fragment.firstChild)) {


### PR DESCRIPTION
いままで AutoPagerize の createHTMLDocumentByString() で作られた Document には head 要素と body 要素が存在していませんでした。
そのため、 `//body/*` のような XPath で pageElement を指定しても、2ページ目以降の createHTMLDocumentByString() によって作られた Document には body 要素がないために pageElement を切り出すことができず、ページの継ぎ足しに失敗する（ので pageElement の指定で body を含む XPath が書けない）という問題がありました。

そこで、 https://github.com/hatena/hatena-bookmark-xul/blob/master/chrome/content/common/05-HTMLDocumentCreator.js のコードを利用して head と body 要素を自作するようにしました。

head 要素を自力で作るため、その子要素となる要素を指定する必要がありますが、ここでは
- base
- link
- meta
- script
- style
- title

を head 要素の子とするようにしました。
この部分については、AutoPatchWorkのコード (https://code.google.com/p/autopatchwork/source/browse/AutoPatchWork/includes/AutoPatchWork.js#617) を利用しました。
これは HTML4.01 Transitional (http://www.w3.org/TR/html401/sgml/loosedtd.html#head.content) で head の子要素になりうる
- base
- isindex
- link
- meta
- object
- script
- style
- title

と、HTML5 (http://www.w3.org/TR/html5/content-models.html#metadata-content) で head の子要素になりうる
- base
- command
- link
- meta
- noscript
- script
- style
- title

の共通集合をとった形になります（もとの AutoPatchWork のコードがそういう意図なのかはわかりませんが）。
「もともと body の子として存在した object 要素が createHTMLDocumentByString() で作られた Document では head の子要素になる」といった事態が生じることもないので、共通集合をとるという方針でいいのではないかと思っています。

もっとも、もう少し先の Firefox では XMLHttpRequest Level 2 の仕様に従って response を DOM として扱えるようになる (https://bugzilla.mozilla.org/show_bug.cgi?id=651072) ようなので、そうなればこういう手順を踏まなくてもよくなりそうですが。
