### PR TITLE
updated Add-on SDK version for Firefox 9.

### DIFF
--- a/README
+++ b/README
@@ -1,7 +1,7 @@
 AutoPagerize Firefox Extension with Add-on SDK
 
 # Require
- Add-on SDK 1.2.1
+ Add-on SDK 1.3
 
 # Build
  cfx xpi


### PR DESCRIPTION
今 AutoPagerize の xpi をビルドしているのは Add-on SDK 1.2.1 ですが, これがサポートしているのは Firefox 8 までです (minVersion: 7.0, maxVersion: 8._).
既に Firefox 9 がリリースされているので, Firefox 9 をサポートしている Add-on SDK 1.3 (minVersion: 8.0, maxVersion: 9._) で xpi をビルドしていただけると幸いです.

念のために Mozilla/5.0 (X11; Linux i686; rv:9.0) Gecko/20100101 Firefox/9.0 を用いて Add-on SDK 1.3 でビルドした AutoPagerize の動作を以下のページでテストしましたが, 特に問題が生じている様子はありませんでした.
- http://misc-xkyrgyzstan.dotcloud.com/aptests/html/normal
- http://misc-xkyrgyzstan.dotcloud.com/aptests/html/tr
- http://misc-xkyrgyzstan.dotcloud.com/aptests/xhtml/normal
- http://misc-xkyrgyzstan.dotcloud.com/aptests/xhtml/tr

コンテキストメニューからの各種設定や SITEINFO のアップデートも問題なく行えることを確認しました.

よろしくおねがいします.
