### PR TITLE
fixed httpOnly cookie issue (for http://www.tumblr.com/dashboard/)

### DIFF
--- a/data/autopagerize.user.js
+++ b/data/autopagerize.user.js
@@ -210,7 +210,7 @@ AutoPager.prototype.request = function() {
     this.lastRequestURL = this.requestURL
     this.showLoading(true)
     if (Extension.isFirefox()) {
-        extension.postMessage('get', { url:  this.requestURL, fromURL: location.href, charset: document.characterSet, cookie: document.cookie }, function(res) {
+        extension.postMessage('get', { url:  this.requestURL, fromURL: location.href, charset: document.characterSet }, function(res) {
             if (res.responseText && res.finalURL) {
                 self.load(createHTMLDocumentByString(res.responseText), res.finalURL)
             }

--- a/lib/main.js
+++ b/lib/main.js
@@ -6,6 +6,7 @@ var localStorage = require('simple-storage').storage
 var panels = require('panel')
 var tabs = require('tabs')
 var url = require('url')
+var {Cc, Ci} = require('chrome')
 
 var SITEINFO_IMPORT_URLS = [
     'http://wedata.net/databases/AutoPagerize/items.json',
@@ -142,7 +143,7 @@ function onAttach(worker) {
             launched[message.data.url] = true
         }
         else if (message.name == 'get') {
-            var cookie = isSameOrigin(message.data.fromURL, message.data.url) ? message.data.cookie : null
+            var cookie = getCookie(message.data.fromURL, message.data.url)
             get(message.data.url, function(res) {
                 var issame = isSameOrigin(message.data.fromURL,
                                           res.finalURL)
@@ -276,4 +277,23 @@ function attachAll(contentScript, urlpattern) {
             tabs[i].attach({ contentScript: contentScript })
         }
     }
+}
+
+function getCookie(from, to) {
+    if (!isSameOrigin(from, to)) {
+        return ''
+    }
+    var toUrl = new url.URL(to)
+    var needSecureCookie = toUrl.scheme == 'https'
+    var result = []
+    var cookieManager = Cc['@mozilla.org/cookiemanager;1'].getService(Ci.nsICookieManager2)
+    var enumerator = cookieManager.getCookiesFromHost(toUrl.host)
+    var cookie
+    while (enumerator.hasMoreElements()) {
+        cookie = enumerator.getNext().QueryInterface(Ci.nsICookie2)
+        if (!cookie.isSecure || needSecureCookie) {
+            result.push(cookie.name + '=' + cookie.value)
+        }
+    }
+    return result.join('; ')
 }


### PR DESCRIPTION
サードパーティ cookie をオフにし， Tumblr の「Enable endless scrolling」のチェックを外した状態で http://www.tumblr.com/dashboard/ でAutoPagerize を動作させると，次のページを読み込めずにエラーになります．

http://www.tumblr.com/dashboard/ で次ページを継ぎ足すためには， httponly 属性が付いた cookie をリクエストの際に送る必要があります．
`document.cookie` では httponly 属性の付いた cookie の情報を得られないので，
content script ではなく Add-on script 側で送信すべき cookie の情報を取得することで，
httponly 属性付きの cookie も送信できるように変更しました．
