### PR TITLE
 added support for Google Instant

### DIFF
--- a/data/autopagerize.user.js
+++ b/data/autopagerize.user.js
@@ -300,14 +300,6 @@ AutoPager.prototype.addPage = function(htmlDoc, page) {
     p.setAttribute('class', 'autopagerize_page_info')
     var self = this
 
-    if (getRoot(this.insertPoint) != document) {
-        var lastPageElement = getElementsByXPath(this.info.pageElement).pop()
-        if (lastPageElement) {
-            this.insertPoint = lastPageElement.nextSibling ||
-                lastPageElement.parentNode.appendChild(document.createTextNode(' '))
-        }
-    }
-
     if (page[0] && /tr/i.test(page[0].tagName)) {
         var insertParent = this.insertPoint.parentNode
         var colNodes = getElementsByXPath('child::tr[1]/child::*[self::td or self::th]', insertParent)
@@ -784,16 +776,6 @@ function createDocumentFragmentByString(str) {
     var range = document.createRange()
     range.setStartAfter(document.body)
     return range.createContextualFragment(str)
-}
-
-function getRoot(element) {
-    var limit = 1000
-    for (var i = 0; i < limit; i++) {
-        if (!element.parentNode) {
-            return element
-        }
-        element = element.parentNode
-    }
 }
 
 })()


### PR DESCRIPTION
Google でインスタント検索を有効にした状態で，
1. Firefox の右上にある検索ボックスに「foo」を入力し Google 検索
2. Google の検索結果ページの上部にある検索ボックスから「foo」を消し「bar」を入力して検索
3. スクロールして AutoPagerize で次ページを継ぎ足す

という手順で検索した際に、2ページ目以降に「bar」で検索した結果ではなく「foo」で検索した結果のページが継ぎ足されるという具合になっていました。

これは「foo」で検索した際に取得した nextLink の URL が「bar」で検索し直した際に更新されずそのままであることが原因です。
そこで AutoPagerize が次ページへのリクエストを出す際に insertPoint が現在の document に属しているかを確認し、
属していなければ既に取得した nextLink なども現在の document に属さず情報が古くなっているものと仮定して再度取得し直すように変更を加えました。
