### PR TITLE
use standard `responseURL` instead of `finalURL`

### DIFF
--- a/data/autopagerize.user.js
+++ b/data/autopagerize.user.js
@@ -211,8 +211,8 @@ AutoPager.prototype.request = function() {
     this.showLoading(true)
     if (Extension.isFirefox()) {
         extension.postMessage('get', { url:  this.requestURL, fromURL: location.href, charset: document.characterSet }, function(res) {
-            if (res.responseText && res.finalURL) {
-                self.load(createHTMLDocumentByString(res.responseText), res.finalURL)
+            if (res.responseText && res.responseURL) {
+                self.load(createHTMLDocumentByString(res.responseText), res.responseURL)
             }
             else {
                 self.error()

--- a/lib/main.js
+++ b/lib/main.js
@@ -25,12 +25,6 @@ var excludes = [
 var loading_html = ''
 var error_html = ''
 
-xhr.XMLHttpRequest.prototype.__defineGetter__(
-    'finalURL',
-    function() {
-        return (this._req ? this._req.channel : this.channel).URI.spec
-    })
-
 exports.main = function (options, callbacks) {
     if (simpleStorage.settings) {
         // remove obsolete settings.
@@ -153,10 +147,10 @@ function onAttach(worker) {
             var cookie = cookieutil.getCookie(message.data.fromURL, message.data.url)
             get(message.data.url, function(res) {
                 var issame = cookieutil.isSameOrigin(
-                    message.data.fromURL, res.finalURL)
+                    message.data.fromURL, res.responseURL)
                 var d = {
                     responseText : issame ? res.responseText : null,
-                    finalURL : res.finalURL
+                    responseURL : res.responseURL
                 }
                 worker.postMessage({ name: 'get', data: d })
             }, { charset: message.data.charset, cookie: cookie })


### PR DESCRIPTION
現在のstable(Firefox 32) から `finalURL` の代わりに利用できる `XMLHttpRequest.prototype.responseURL` が実装され(https://bugzilla.mozilla.org/show_bug.cgi?id=998076)、
独自に `finalURL` を定義しなくても済むようになりました。

このpull requestでは、XHRの仕様に記載のある `responseURL` の方を `finalURL` の代わりに用いるようにし、
`sdk/net/xhr` モジュールの内部実装に依存している `finalURL` を使わないように変更しています。
ご確認いただければ幸いです。
