### PR TITLE
 fix not to stop when |s.url| is invalid regexp

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -144,7 +144,13 @@ function onAttach(worker) {
             var res_ = SITEINFO_IMPORT_URLS.reduce(function(r, url) {
                 return r.concat(siteinfo[url].info)
             }, []).filter(function(s) {
-                return message.data.url.match(s.url)
+                try {
+                    return message.data.url.match(s.url)
+                }
+                catch(e) {
+                    console.log(e)
+                    return false
+                }
             })
             worker.postMessage({ name: 'siteinfo', data: res_ })
         }


### PR DESCRIPTION
Wedata上のSITEINFOに、正規表現の文法誤りのあるものが含まれている場合AutoPagerizeが動作しなくなるということがありました。
http://xkansan.tumblr.com/post/97476061484/autopagerize-wedata に記載しています。

上記事例が発生していた際の SITEINFO を CocProxy を使ってローカルで用いるようにして確認したところ、
lib/main.js 内のSITEINFOの絞り込みをしている部分でエラーが発生してその後の処理が止まっていたため、その部分を変更しています。

変更前後の動作確認に用いた items_all.json は以下のとおりです：

``` json
[
    {
        "resource_url": "http://wedata.net/items/76326?rev=125099",
        "database_resource_url": "http://wedata.net/databases/AutoPagerize",
        "data": {
            "exampleUrl": "http://beatarai.blog90.fc2.com/",
            "pageElement": "//div[@id=\"mainBlock\"\"]",
            "nextLink": "//a[contains(text(), \"Next\")",
            "url": "http://beatarai\\.blog90\\.fc2\\.com/(page-[\\dhtml)?"
        },
        "created_by": "kd_ty_zi",
        "name": "大炎上",
        "created_at": "2014-09-14T06:53:31+09:00",
        "updated_at": "2014-09-15T07:56:13+09:00"
    }
]
```
